### PR TITLE
remove rogue `ext = ...` line from assessment section 2.1

### DIFF
--- a/assessment/final-assessment.ipynb
+++ b/assessment/final-assessment.ipynb
@@ -263,7 +263,6 @@
     "    '''\n",
     "    server = \"http://rest.ensembl.org\"\n",
     "    ext = \"/homology/id/{0}?target_taxon={1};type=orthologues;sequence=cdna\"\n",
-    "    ext = ...\n",
     "    response = requests.get(server+ext, headers={ \"Content-Type\" : \"application/json\"})\n",
     "    if not response.ok:\n",
     "        response.raise_for_status()\n",

--- a/assessment/final-assessment.ipynb
+++ b/assessment/final-assessment.ipynb
@@ -262,7 +262,7 @@
     "    - The decoded JSON response from the Ensembl Homology endpoint\n",
     "    '''\n",
     "    server = \"http://rest.ensembl.org\"\n",
-    "    ext = \"/homology/id/{0}?target_taxon={1};type=orthologues;sequence=cdna\"\n",
+    "    ext = \"/homology/id/{0}?target_taxon={1};type=orthologues;sequence=cdna\".format(...)\n",
     "    response = requests.get(server+ext, headers={ \"Content-Type\" : \"application/json\"})\n",
     "    if not response.ok:\n",
     "        response.raise_for_status()\n",


### PR DESCRIPTION
For the avoidance of confusion, I think we should remove this line from the code block in section 2.1.